### PR TITLE
Fix config name error and create pr

### DIFF
--- a/config.py
+++ b/config.py
@@ -152,7 +152,8 @@ class TestingConfig(Config):
     """הגדרות לבדיקות"""
     LOG_LEVEL = 'ERROR'
     DATABASE_NAME = ':memory:'  # מסד נתונים זמני בזיכרון
-    Advanced.ENABLE_REMINDERS = False
+    class Advanced(Config.Advanced):
+        ENABLE_REMINDERS = False
 
 # בחירת הגדרות לפי משתנה סביבה
 ENV = os.getenv('BOT_ENV', 'development').lower()


### PR DESCRIPTION
Fix `NameError` in `TestingConfig` by correctly defining `Advanced` as an inner class inheriting from `Config.Advanced`.

---
<a href="https://cursor.com/background-agent?bcId=bc-bc57d987-3822-4845-b5e9-19f1d7d6507a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bc57d987-3822-4845-b5e9-19f1d7d6507a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

