### PR TITLE
Fix job queue attribute error

### DIFF
--- a/main.py
+++ b/main.py
@@ -577,13 +577,16 @@ class TodoBot:
             self.handle_message
         ))
         
-        # הגדרת תזכורת יומית לשעה 9:00
-        job_queue = self.application.job_queue
-        job_queue.run_daily(
-            self.daily_reminder,
-            time=time(hour=9, minute=0, tzinfo=TIMEZONE),
-            name='daily_reminder'
-        )
+        # הגדרת תזכורת יומית לשעה 9:00 (עם בדיקה שה-JobQueue קיים)
+        job_queue = getattr(self.application, 'job_queue', None)
+        if job_queue is None:
+            logger.warning("No JobQueue available. Install PTB with job-queue extra or check application setup.")
+        else:
+            job_queue.run_daily(
+                self.daily_reminder,
+                time=time(hour=9, minute=0, tzinfo=TIMEZONE),
+                name='daily_reminder'
+            )
 
     def run(self):
         """הרצת הבוט"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # ספריות נדרשות לבוט טלגרם לניהול משימות
 
 # ספריות בסיסיות
-python-telegram-bot==20.7
+python-telegram-bot[job-queue]==20.7
 pytz==2023.3
 # sqlite3 נכלל ב-Python
 


### PR DESCRIPTION
Update `python-telegram-bot` dependency to include `[job-queue]` extra and add a guard for `job_queue` usage to fix `AttributeError: 'NoneType' object has no attribute 'run_daily'`.

The `AttributeError` occurred because `python-telegram-bot` was installed without the `job-queue` extra, causing `self.application.job_queue` to be `None`. This PR ensures the `JobQueue` is properly initialized and adds a defensive check to prevent crashes if it's ever unavailable.

---
<a href="https://cursor.com/background-agent?bcId=bc-425248f8-6597-4dcc-92d6-d5ee3ea4ce55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-425248f8-6597-4dcc-92d6-d5ee3ea4ce55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

