### PR TITLE
Fix python telegram bot webhook installation error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # ספריות נדרשות לבוט טלגרם לניהול משימות
 
 # ספריות בסיסיות
-python-telegram-bot[job-queue]==20.7
+python-telegram-bot[webhooks,job-queue]==20.7
 pytz==2023.3
 # sqlite3 נכלל ב-Python
 


### PR DESCRIPTION
Add `[webhooks]` extra to `python-telegram-bot` in `requirements.txt` to enable webhook functionality.

The bot was failing to start in webhook mode with the error: "To use `start_webhook`, PTB must be installed via `pip install "python-telegram-bot[webhooks]"."` This change resolves that dependency requirement.

---
<a href="https://cursor.com/background-agent?bcId=bc-845e8802-d008-4e8a-bd14-bbcf8d7181e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-845e8802-d008-4e8a-bd14-bbcf8d7181e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

